### PR TITLE
Fix authorization

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -4,13 +4,13 @@
 @{
     ViewData["Title"] = "Home page";
 
-    //var latest = await client.GetLatestAsync
-    //    ("https://github.com/aspnet/AspNetCore",
-    //    null, null, null, null, null, false, (ApiVersion10)ApiVersion40._20190116);
-    //var graph = await client.GetBuildGraphAsync(latest.Id, (ApiVersion9)ApiVersion40._20190116);
+    var latest = await client.GetLatestAsync
+        ("https://github.com/aspnet/AspNetCore",
+        null, null, null, null, null, false, (ApiVersion10)ApiVersion40._20190116);
+    var graph = await client.GetBuildGraphAsync(latest.Id, (ApiVersion9)ApiVersion40._20190116);
 
-    var latest = Newtonsoft.Json.JsonConvert.DeserializeObject<Build>(System.IO.File.ReadAllText(@"SampleData\latest.json"));
-    var graph = Newtonsoft.Json.JsonConvert.DeserializeObject<BuildGraph>(System.IO.File.ReadAllText(@"SampleData\graph.json"));
+    //var latest = Newtonsoft.Json.JsonConvert.DeserializeObject<Build>(System.IO.File.ReadAllText(@"SampleData\latest.json"));
+    //var graph = Newtonsoft.Json.JsonConvert.DeserializeObject<BuildGraph>(System.IO.File.ReadAllText(@"SampleData\graph.json"));
     var build = graph.Builds[latest.Id.ToString()];
 }
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Net.Http.Headers;
 
 namespace DependencyFlow
 {
@@ -27,8 +28,10 @@ namespace DependencyFlow
             services.AddHttpClient<swaggerClient>(client =>
             {
                 var authToken = Configuration["AuthToken"];
+                client.DefaultRequestHeaders.Add(HeaderNames.UserAgent, "Kevin's cool thing.");
                 client.DefaultRequestHeaders.Add(
-                    "Authorize", new AuthenticationHeaderValue("msft", authToken).ToString());
+                    HeaderNames.Authorization, 
+                    new AuthenticationHeaderValue("Bearer", authToken).ToString());
             });
 
             services.AddRazorPages();


### PR DESCRIPTION
There were two mistakes here:
- The header name should be Authorization (oops my bad)
- The scheme name needs to be Bearer

Make sure that you're using a PAT from the correct instance of the app.
For example Maestro is deployed at:
https://maestro-prod.westus2.cloudapp.azure.com AND
https://maestro-int.westus2.cloudapp.azure.com

If you're talking to https://maestro-prod.westus2.cloudapp.azure.com
then get a token from
https://maestro-prod.westus2.cloudapp.azure.com/Account/Tokens