### PR TITLE
More accurate commit age

### DIFF
--- a/Pages/Incoming.cshtml
+++ b/Pages/Incoming.cshtml
@@ -2,10 +2,10 @@
 @model IncomingModel
 
 <div class="card-deck">
-    @{ 
+    @{
         var index = 0;
     }
-    @foreach (var incoming in Model.IncomingRepositories.OrderByDescending(r => r.Build.DateProduced))
+    @foreach (var incoming in Model.IncomingRepositories.OrderByDescending(r => r.CommitAge))
     {
         // We compute the "condition" of a dependency by first checking how old the build we have is.
         // If it's older than we'd like, we then ALSO check the number of commits that we're missing
@@ -16,7 +16,7 @@
         string textClass = "text-white";
         string linkClass = "link-light";
 
-        var elapsed = DateTime.UtcNow - incoming.Build.DateProduced.UtcDateTime;
+        var elapsed = DateTime.UtcNow - incoming.CommitAge.UtcDateTime;
         if (elapsed.TotalDays < 3 || incoming.CommitDistance < 25)
         {
             conditionClass = "bg-primary";
@@ -39,7 +39,7 @@
                     @(incoming.CommitDistance == null ? "??? commits behind" : incoming.CommitDistance == 0 ? "✔" : $"{incoming.CommitDistance} commit behind")
                 </h5>
                 <p class="card-text"><a class="@linkClass" target="_blank" href="@incoming.BuildUrl">Build @incoming.Build.AzureDevOpsBuildNumber</a></p>
-                <p class="card-text">@incoming.Build.DateProduced.Humanize()</p>
+                <p class="card-text">@incoming.CommitAge.Humanize()</p>
             </div>
             <div class="card-footer">
                 <a class="@linkClass" target="_blank" href="@incoming.CommitUrl">@incoming.Build.Commit.Substring(0, 6)</a>

--- a/Pages/Incoming.cshtml
+++ b/Pages/Incoming.cshtml
@@ -15,20 +15,23 @@
         string conditionClass;
         string textClass = "text-white";
         string linkClass = "link-light";
+        string statusIcon = "✔️";
 
         var elapsed = DateTime.UtcNow - incoming.CommitAge.UtcDateTime;
-        if (elapsed.TotalDays < 3 || incoming.CommitDistance < 25)
+        if (incoming.CommitDistance == 0 || elapsed.TotalDays < 5)
         {
             conditionClass = "bg-primary";
         }
         else if (elapsed.TotalDays < 7)
         {
+            statusIcon = "⚠";
             conditionClass = "bg-warning";
             textClass = null;
             linkClass = null;
         }
         else
         {
+            statusIcon = "❌";
             conditionClass = "bg-danger";
         }
 
@@ -36,10 +39,12 @@
             <div class="card-header">@incoming.ShortName</div>
             <div class="card-body">
                 <h5 class="card-title">
-                    @(incoming.CommitDistance == null ? "??? commits behind" : incoming.CommitDistance == 0 ? "✔" : $"{incoming.CommitDistance} commit behind")
+                    @statusIcon We are @(incoming.CommitDistance == null ? "(unknown)" : incoming.CommitDistance == 0 ? "0" : $"{incoming.CommitDistance}") commit(s) behind
                 </h5>
+                <p class="card-text">
+                    Oldest unconsumed commit was @incoming.CommitAge.Humanize()
+                </p>
                 <p class="card-text"><a class="@linkClass" target="_blank" href="@incoming.BuildUrl">Build @incoming.Build.AzureDevOpsBuildNumber</a></p>
-                <p class="card-text">@incoming.CommitAge.Humanize()</p>
             </div>
             <div class="card-footer">
                 <a class="@linkClass" target="_blank" href="@incoming.CommitUrl">@incoming.Build.Commit.Substring(0, 6)</a>

--- a/Startup.cs
+++ b/Startup.cs
@@ -28,7 +28,7 @@ namespace DependencyFlow
                 var authToken = Configuration["AuthToken"];
                 client.DefaultRequestHeaders.Add(HeaderNames.UserAgent, UserAgentValue);
                 client.DefaultRequestHeaders.Add(
-                    HeaderNames.Authorization, 
+                    HeaderNames.Authorization,
                     new AuthenticationHeaderValue("Bearer", authToken).ToString());
             });
 


### PR DESCRIPTION
This will use the age of either:
* the oldest commit not consumed
* the newest commit consumed

depending on which one is newer.

e.g. Extensions hasn't had a commit in 6 days and someone pushes a new commit. The board will now show 0 days instead of 6.

@Pilchie 