### PR TITLE
Sort by repo name for stability

### DIFF
--- a/Pages/Incoming.cshtml
+++ b/Pages/Incoming.cshtml
@@ -5,7 +5,7 @@
     @{
         var index = 0;
     }
-    @foreach (var incoming in Model.IncomingRepositories.OrderByDescending(r => r.CommitAge))
+    @foreach (var incoming in Model.IncomingRepositories.OrderByDescending(r => r.ShortName))
     {
         // We compute the "condition" of a dependency by first checking how old the build we have is.
         // If it's older than we'd like, we then ALSO check the number of commits that we're missing


### PR DESCRIPTION
@Tratcher noticed that the order changed somewhat randomly on the dashboard. We should consider sorting by repo short name instead.

@anurse @halter73 @BrennanConroy @rynowak Thoughts?