### PR TITLE
Extend warning/failure windows for dotnet/roslyn dependency

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -12,6 +12,10 @@
       "dotnet/arcade": {
         "WarningUnconsumedCommitAge": 8,
         "FailUnconsumedCommitAge": 11
+      },
+      "dotnet/roslyn": {
+        "WarningUnconsumedCommitAge": 8,
+        "FailUnconsumedCommitAge": 11
       }
     }
   }


### PR DESCRIPTION
This subscription flows once per week, so it would always be yellow or red if we held it to the 5 day/7 day SLA. Extending it to match the window of dotnet/arcade, which has the same update frequency.

@Pilchie PTAL