### PR TITLE
Fallback to build date if commit history too long

### DIFF
--- a/Pages/Incoming.cshtml
+++ b/Pages/Incoming.cshtml
@@ -19,7 +19,7 @@
         string? linkClass = "link-light";
         string statusIcon = "✔️";
 
-        var elapsed = (incoming.CommitAge == null ? TimeSpan.FromDays(100) : DateTime.UtcNow - incoming.CommitAge.Value.UtcDateTime);
+        var elapsed = DateTime.UtcNow - incoming.CommitAge.UtcDateTime;
         if (incoming.CommitDistance == 0 || elapsed.TotalDays < Model.SlaOptions.GetForRepo(incoming.ShortName).WarningUnconsumedCommitAge)
         {
             conditionClass = "bg-primary";

--- a/Pages/Incoming.cshtml.cs
+++ b/Pages/Incoming.cshtml.cs
@@ -84,7 +84,7 @@ namespace DependencyFlow.Pages
         }
 
         public string GetBuildUrl(Build? build)
-            => build == null 
+            => build == null
                 ? "(unknown)"
                 : $"https://dev.azure.com/{build.AzureDevOpsAccount}/{build.AzureDevOpsProject}/_build/results?buildId={build.AzureDevOpsBuildId}&view=results";
 
@@ -128,9 +128,9 @@ namespace DependencyFlow.Pages
             }
         }
 
-        private async Task<(int?, DateTimeOffset?)> GetCommitInfo(GitHubInfo? gitHubInfo, Build build)
+        private async Task<(int?, DateTimeOffset)> GetCommitInfo(GitHubInfo? gitHubInfo, Build build)
         {
-            DateTimeOffset? commitAge = build.DateProduced;
+            DateTimeOffset commitAge = build.DateProduced;
             int? commitDistance = null;
             if (gitHubInfo != null)
             {
@@ -159,9 +159,10 @@ namespace DependencyFlow.Pages
 
                         if (foundCommit == false)
                         {
-                            // something went wrong
-                            _logger.LogWarning("Failed to follow commit parents and find correct commit age.");
-                            commitAge = null;
+                            // Happens if there are over 250 commits
+                            // We would need to use a paging API to follow commit history over 250 commits
+                            _logger.LogDebug("Failed to follow commit parents and find correct commit age. Falling back to the date the build was produced");
+                            commitAge = build.DateProduced;
                             return (commitDistance, commitAge);
                         }
                     }
@@ -180,9 +181,9 @@ namespace DependencyFlow.Pages
         public int? CommitDistance { get; }
         public string CommitUrl { get; }
         public string BuildUrl { get; }
-        public DateTimeOffset? CommitAge { get; }
+        public DateTimeOffset CommitAge { get; }
 
-        public IncomingRepo(Build build, string shortName, int? commitDistance, string commitUrl, string buildUrl, DateTimeOffset? commitAge)
+        public IncomingRepo(Build build, string shortName, int? commitDistance, string commitUrl, string buildUrl, DateTimeOffset commitAge)
         {
             Build = build;
             ShortName = shortName;


### PR DESCRIPTION
If the commit age can't be found we should probably fallback to the date the build was produced. It might be a little inaccurate, but probably better than "(unknown)"

![image](https://user-images.githubusercontent.com/7574801/77602207-1439c180-6eca-11ea-91a6-20c874d47b54.png)

@Pilchie 