### PR TITLE
Start the clock from the oldest unconsumed build

### DIFF
--- a/Pages/Incoming.cshtml
+++ b/Pages/Incoming.cshtml
@@ -19,12 +19,17 @@
         string? linkClass = "link-light";
         string statusIcon = "✔️";
 
-        var elapsed = DateTime.UtcNow - incoming.CommitAge.UtcDateTime;
-        if (incoming.CommitDistance == 0 || elapsed.TotalDays < Model.SlaOptions.GetForRepo(incoming.ShortName).WarningUnconsumedCommitAge)
+        var elapsed = TimeSpan.Zero;
+        if (incoming.OldestPublishedButUnconsumedBuild != null)
+        {
+            elapsed = DateTime.UtcNow - incoming.OldestPublishedButUnconsumedBuild.DateProduced;
+        }
+
+        if (incoming.OldestPublishedButUnconsumedBuild == null || elapsed.TotalDays < Model.SlaOptions.GetForRepo(incoming.ShortName).WarningUnconsumedBuildAge)
         {
             conditionClass = "bg-primary";
         }
-        else if (elapsed.TotalDays < Model.SlaOptions.GetForRepo(incoming.ShortName).FailUnconsumedCommitAge)
+        else if (elapsed.TotalDays < Model.SlaOptions.GetForRepo(incoming.ShortName).FailUnconsumedBuildAge)
         {
             statusIcon = "⚠";
             conditionClass = "bg-warning";
@@ -44,11 +49,11 @@
                     @statusIcon We are @(incoming.CommitDistance == null ? "(unknown)" : incoming.CommitDistance == 0 ? "0" : $"{incoming.CommitDistance}") commit(s) behind
                 </h5>
                 <p class="card-text">
-                    Oldest unconsumed commit was @(incoming.CommitAge == null ? "(unknown)" : incoming.CommitAge.Humanize())
+                    Oldest unconsumed - build: @(incoming.OldestPublishedButUnconsumedBuild == null ? "none" : incoming.OldestPublishedButUnconsumedBuild.DateProduced.Humanize()) / commit: @(incoming.CommitAge == null ? "(unknown)" : incoming.CommitAge.Humanize())
                 </p>
             </div>
             <div class="card-footer">
-                <a class="@linkClass" target="_blank" href="@incoming.BuildUrl">Build @incoming.Build.AzureDevOpsBuildNumber</a> | <a class="@linkClass" target="_blank" href="@incoming.CommitUrl">@incoming.Build.Commit.Substring(0, 6)</a>
+                <a class="@linkClass" target="_blank" href="@incoming.BuildUrl">Build @incoming.LastConsumedBuild.AzureDevOpsBuildNumber</a> | <a class="@linkClass" target="_blank" href="@incoming.CommitUrl">@incoming.LastConsumedBuild.Commit.Substring(0, 6)</a>
             </div>
         </div>
 

--- a/SlaOptions.cs
+++ b/SlaOptions.cs
@@ -11,7 +11,7 @@ namespace DependencyFlow
         public IDictionary<string, Sla> Repositories { get; } =
             new Dictionary<string, Sla>
             {
-                { "[Default]", new Sla { FailUnconsumedCommitAge = 7, WarningUnconsumedCommitAge = 5 } },
+                { "[Default]", new Sla { FailUnconsumedBuildAge = 7, WarningUnconsumedBuildAge = 5 } },
             };
 
         public Sla GetForRepo(string repoShortName)
@@ -28,10 +28,10 @@ namespace DependencyFlow
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     public class Sla
     {
-        public int WarningUnconsumedCommitAge { get; set; }
-        public int FailUnconsumedCommitAge { get; set; }
+        public int WarningUnconsumedBuildAge { get; set; }
+        public int FailUnconsumedBuildAge { get; set; }
 
         private string GetDebuggerDisplay()
-             => $"{nameof(Sla)}(Warn: {WarningUnconsumedCommitAge}, Fail: {FailUnconsumedCommitAge})";
+             => $"{nameof(Sla)}(Warn: {WarningUnconsumedBuildAge}, Fail: {FailUnconsumedBuildAge})";
     }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -10,12 +10,12 @@
   "SLAs": {
     "Repositories": {
       "dotnet/arcade": {
-        "WarningUnconsumedCommitAge": 11,
-        "FailUnconsumedCommitAge": 14
+        "WarningUnconsumedBuildAge": 11,
+        "FailUnconsumedBuildAge": 14
       },
       "dotnet/roslyn": {
-        "WarningUnconsumedCommitAge": 11,
-        "FailUnconsumedCommitAge": 14
+        "WarningUnconsumedBuildAge": 11,
+        "FailUnconsumedBuildAge": 14
       }
     }
   }


### PR DESCRIPTION
Previously we were starting the clock as soon as a commit was pushed to
the branch our dependency's build came from.  That's not actionable,
since we actually need a build to be produced, and that build to be
pushed to the channel we're consuming before we *can* consume that
dependency.

This changes the calculation to "start the clock" for the SLA from the
time the oldest build currently published was produced.  This still
isn't ideal because a build could be produced but not published, sit
around for a week and then get published to the channel.  At that point
we would suddenly be out of SLA, even though there is nothing we could
have done.  Alas, the Maestro APIs don't seem to provide information
about *when* a particular build is published though, so this will have
to do for now.